### PR TITLE
chore: unpin @slidev/cli now that --base navigation is fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
       default-days: 3
       semver-major-days: 7
       semver-minor-days: 5
-    ignore:
-      # 52.16.0 double-prefixes --base, breaking navigation on subdirectory deploys
-      # (slidevjs/slidev#2622, #2629). Remove once a fixed release is out.
-      - dependency-name: "@slidev/cli"
-        versions: ["52.16.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ catalogs:
       specifier: ^0.4.6
       version: 0.4.6
     '@slidev/cli':
-      specifier: 52.18.0
+      specifier: ^52.18.0
       version: 52.18.0
     '@slidev/theme-default':
       specifier: latest
@@ -41,6 +41,8 @@ importers:
   2025-08-10/src: {}
 
   2025-11-25/src: {}
+
+  2026-08-09/src: {}
 
 packages:
 
@@ -4445,6 +4447,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -4654,7 +4663,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.140.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,6 @@ packages:
 
 catalog:
   '@aotoki/slidev-theme-terraforming': ^0.4.6
-  # Pinned: 52.16.0 double-prefixes --base in getSlidePath, breaking navigation on
-  # subdirectory deploys (slidevjs/slidev#2622, #2629). Unpin once upstream ships a fix.
-  '@slidev/cli': 52.18.0
+  '@slidev/cli': ^52.18.0
   '@slidev/theme-default': latest
   '@slidev/theme-seriph': latest


### PR DESCRIPTION
Removes the `@slidev/cli` exact pin and the matching dependabot `52.16.0` ignore, now that #39 landed 52.18.0.

**Verification** — the 52.16.0 regression (base double-prefix) is gone:
- `packages/client/logic/slidePath.ts` (52.18.0) returns `/${no}` with no `import.meta.env.BASE_URL` prefix; the router history is the only place applying the base.
- Built `2025-08-10` with `--base /2025-08-10-coscup/`: the bundle contains `` `/export/${r}` : `/presenter/${r}` : `/${r}` `` and the base string only inside `createWebHashHistory('/2025-08-10-coscup/')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)